### PR TITLE
correct conflict from as.Date2.character()

### DIFF
--- a/R/sqldf.R
+++ b/R/sqldf.R
@@ -15,7 +15,7 @@ sqldf <- function(x, stringsAsFactors = FALSE,
 	class = c("POSIXct", "POSIXt"))
    as.Date.character <- function(x) structure(as.numeric(x), class = "Date")
    as.Date2 <- function(x) UseMethod("as.Date2")
-   as.Date2.character <- function(x) as.Date.character(x)
+   as.Date2.character <- function(x) base::as.Date.character(x)
    as.Date.numeric <- function(x, origin = "1970-01-01", ...) base::as.Date.numeric(x, origin = origin, ...)
    as.dates.character <- function(x) structure(as.numeric(x), class = c("dates", "times"))
    as.times.character <- function(x) structure(as.numeric(x), class = "times")


### PR DESCRIPTION
`Date2` class is used to treat the dates with format `yyyy-mm-dd`. In the function `as.Date2.character`:

```
as.Date2.character <- function(x) as.Date.character(x)
```

`as.Date.character` in `base` is used to convert a `yyyy-mm-dd`-format character string to `Date` object in R, but this function have been re-defined in the previous code:

```r
as.Date.character <- function(x) structure(as.numeric(x), class = "Date")
```

and thereby overrides that in `base`.

Example:

```r
DF <- data.frame(x = "2022-01-01")
sqldf("select x as y__Date2 from DF", method = "name__class")
# or equivalently
sqldf("select x as y from DF", method = "Date2")
```

> Warning message:
In structure(as.numeric(x), class = "Date") : NAs introduced by coercion

This issue can be solved by inserting a leading `base::` when calling `as.Date.character` in `as.Date2.character`.

```r
DF2 <- sqldf("select x as y__Date2 from DF", method = "name__class")
str(DF2)

# 'data.frame':	1 obs. of  1 variable:
#  $ y: Date, format: "2022-01-01"
```

