### PR TITLE
WIP enable extra extensions, not just math

### DIFF
--- a/R/sqldf.R
+++ b/R/sqldf.R
@@ -259,8 +259,16 @@ sqldf <- function(x, stringsAsFactors = FALSE,
 				}
 				connection <- dbConnect(m, dbname = dbname)
 			}
+			
 			if (verbose) cat("sqldf: initExtension(connection)\n")
-			initExtension(connection)
+			ext_args <- formals(initExtension)
+			if(! "extension" %in% names(ext_args)) {
+			  initExtension(connection)
+			} else {
+			  ext_args <-eval(ext_args$extension)
+			  lapply(ext_args, initExtension,db=connection)
+			}
+			
     	}
 		attr(connection, "dbPreExists") <- dbPreExists
 		if (missing(dbname) && drv == "sqlite") dbname <- ":memory:"


### PR DESCRIPTION
Check for extension parameter on RSQLite::initExtension, and if present, load all default extensions.

The handling of extensions in RSQLite changed in version 2.2.11. This PR should allow the usage of regular expressions.
